### PR TITLE
Add portrait tuning and optional page animation settings patch

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1290,101 +1290,106 @@ function UIManager:_repaint()
         self:_refresh("partial")
     end
 
-    -- Execute a software swipe animation when requested on non-MTK devices.
+-- Execute a software swipe animation when requested on non-MTK devices.
     local software_animate = false
     if Screen.swipe_animations then
-        local is_mtk = Screen.device and Screen.device.isMTK and Screen.device:isMTK()
-        if not is_mtk then
-            software_animate = true
-        end
+        software_animate = true
     end
 
     if software_animate then
+        -- Disable hardware swipe animations and take over refresh counting manually
         Screen.swipe_animations = false
         self.refresh_counted = true
 
+        -- ==================== Integration with page-turn-animation-settings plugin ====================
+        -- Support custom per-orientation animation frame delay set by the external plugin
+
+        -- Default animation frame delays (used when no custom value is set by user):
+        --   Landscape:          10ms  
+        --   Portrait (normal):  22ms 
+        --   Portrait (rotated): 16ms  
+        local screen_w = Screen.bb:getWidth()
+        local screen_h = Screen.bb:getHeight()
+        local is_landscape = screen_w > screen_h
+
+        local function getSwipeAnimationDelayMs()
+            -- Check user configured delay from plugin settings
+            if is_landscape then
+                local delay = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_horizontal")) or 0
+                if delay > 0 then return delay end
+            else
+                local delay = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_vertical")) or 0
+                if delay > 0 then return delay end
+            end
+            -- Fallback to automatic default values
+            if is_landscape then
+                return 10
+            else
+                local rotation_mode = Screen:getRotationMode()
+                local native_rotation_mode = Screen.native_rotation_mode or Screen.DEVICE_ROTATED_UPRIGHT
+                local is_opposite_portrait = bit.band(rotation_mode - native_rotation_mode, 3) == 2
+                return is_opposite_portrait and 16 or 22
+            end
+        end
+
+        local delay_us = getSwipeAnimationDelayMs() * 1000  -- convert ms to μs
+
         local saved_bb = Screen.saved_bb
         Screen.saved_bb = nil
+
         if saved_bb then
             local new_bb = Screen.bb:copy()
 
-            local rotation_mode = Screen:getRotationMode()
-            local native_rotation_mode = Screen.native_rotation_mode or Screen.DEVICE_ROTATED_UPRIGHT
-            local is_opposite_portrait = bit.band(rotation_mode - native_rotation_mode, 3) == 2
-            local screen_w = Screen.bb:getWidth()
-            local screen_h = Screen.bb:getHeight()
-            local is_landscape = screen_w > screen_h
-
-            -- Keep the existing animation profile for upright mode.
-            -- The portrait orientation opposite from the device's native startup
-            -- portrait uses a different generation strategy:
-            -- restore the previous page once, then only draw the newly revealed strip.
+            -- Use fewer animation steps and shorter delay in landscape mode for better visual feel
             local steps = is_landscape and 6 or 8
-            local delay_us = is_landscape and 8000 or (is_opposite_portrait and 16000 or 22000)
-            local delay_setting_key = is_landscape and "swipe_animation_delay_ms_horizontal" or "swipe_animation_delay_ms_vertical"
-            local configured_delay_ms = tonumber(G_reader_settings:readSetting(delay_setting_key)) or 0
-            if configured_delay_ms <= 0 then
-                configured_delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms")) or 0
-            end
-            if configured_delay_ms > 0 then
-                delay_us = configured_delay_ms * 1000
-            end
 
             local swipe_forward = Screen.swipe_forward
             local prev_dx = 0
 
-            if is_landscape or is_opposite_portrait then
-                Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w, screen_h)
-            end
+            -- Draw the previous page as the starting background
+            Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w, screen_h)
 
+            -- Animate page turn by progressively revealing vertical strips of the new page
             for i = 1, steps do
                 local progress = i / steps
                 local dx = math.floor(screen_w * progress)
                 local strip_w = dx - prev_dx
 
                 if strip_w > 0 then
-                    if is_landscape or is_opposite_portrait then
-                        if swipe_forward then
-                            local strip_x = screen_w - dx
-                            Screen.bb:blitFrom(new_bb, strip_x, 0, strip_x, 0, strip_w, screen_h)
-                            Screen:refreshUI(strip_x, 0, strip_w, screen_h)
-                        else
-                            Screen.bb:blitFrom(new_bb, prev_dx, 0, prev_dx, 0, strip_w, screen_h)
-                            Screen:refreshUI(prev_dx, 0, strip_w, screen_h)
-                        end
-                    elseif swipe_forward then
-                        Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w - dx, screen_h)
-                        Screen.bb:blitFrom(new_bb, screen_w - dx, 0, screen_w - dx, 0, dx, screen_h)
-                        Screen:refreshUI(screen_w - dx, 0, strip_w, screen_h)
+                    local strip_x
+                    if swipe_forward then
+                        -- Swipe forward (right to left): reveal from the right edge
+                        strip_x = screen_w - dx
                     else
-                        Screen.bb:blitFrom(new_bb, 0, 0, 0, 0, dx, screen_h)
-                        Screen.bb:blitFrom(saved_bb, dx, 0, dx, 0, screen_w - dx, screen_h)
-                        Screen:refreshUI(prev_dx, 0, strip_w, screen_h)
+                        -- Swipe backward (left to right): reveal from the left edge
+                        strip_x = prev_dx
                     end
+
+                    -- Copy a vertical strip from the new page onto the current screen buffer
+                    Screen.bb:blitFrom(new_bb, strip_x, 0, strip_x, 0, strip_w, screen_h)
+                    Screen:refreshUI(strip_x, 0, strip_w, screen_h)
                 end
 
                 prev_dx = dx
 
+                -- Control animation speed with microsecond delay between strips
                 if ffi and ffi.C and ffi.C.usleep then
                     ffi.C.usleep(delay_us)
                 end
             end
 
-            -- Skip the animation-specific full-refresh counter in night mode
-            -- to avoid an extra flash during dark reading.
-            if not G_reader_settings:isTrue("night_mode")
-                or G_reader_settings:isTrue("swipe_animation_night_full_refresh") then
-                if self.FULL_REFRESH_COUNT and self.FULL_REFRESH_COUNT > 0 then
-                    if not self._swipe_full_refresh_count then
-                        self._swipe_full_refresh_count = 0
-                    end
+            -- Independent full refresh counter
+            -- Periodically triggers a full screen refresh according to the user's
+            -- FULL_REFRESH_COUNT setting (from E-ink options) to reduce ghosting
+            if self.FULL_REFRESH_COUNT and self.FULL_REFRESH_COUNT > 0 then
+                if not self._swipe_full_refresh_count then
+                    self._swipe_full_refresh_count = 0
+                end
+                self._swipe_full_refresh_count = self._swipe_full_refresh_count + 1
 
-                    self._swipe_full_refresh_count = self._swipe_full_refresh_count + 1
-
-                    if self._swipe_full_refresh_count >= self.FULL_REFRESH_COUNT then
-                        Screen:refreshFull(0, 0, screen_w, screen_h)
-                        self._swipe_full_refresh_count = 0
-                    end
+                if self._swipe_full_refresh_count >= self.FULL_REFRESH_COUNT then
+                    Screen:refreshFull(0, 0, screen_w, screen_h)
+                    self._swipe_full_refresh_count = 0
                 end
             end
 
@@ -1393,6 +1398,7 @@ function UIManager:_repaint()
             saved_bb:free()
         end
     end
+    
     -- execute refreshes:
     for _, refresh in ipairs(self._refresh_stack) do
         -- Honor dithering hints from *anywhere* in the dirty stack

--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1293,83 +1293,106 @@ function UIManager:_repaint()
     -- Execute a software swipe animation when requested on non-MTK devices.
     local software_animate = false
     if Screen.swipe_animations then
+        local is_mtk = Screen.device and Screen.device.isMTK and Screen.device:isMTK()
+        if not is_mtk then
             software_animate = true
         end
+    end
 
-	 if software_animate then
-		-- Disable hardware swipe animations and take over refresh counting manually
-		Screen.swipe_animations = false
-		self.refresh_counted = true
+    if software_animate then
+        Screen.swipe_animations = false
+        self.refresh_counted = true
 
-		local saved_bb = Screen.saved_bb
-		Screen.saved_bb = nil
+        local saved_bb = Screen.saved_bb
+        Screen.saved_bb = nil
+        if saved_bb then
+            local new_bb = Screen.bb:copy()
 
-		if saved_bb then
-			local new_bb = Screen.bb:copy()
-			local screen_w = Screen.bb:getWidth()
-			local screen_h = Screen.bb:getHeight()
-			local is_landscape = screen_w > screen_h
+            local rotation_mode = Screen:getRotationMode()
+            local native_rotation_mode = Screen.native_rotation_mode or Screen.DEVICE_ROTATED_UPRIGHT
+            local is_opposite_portrait = bit.band(rotation_mode - native_rotation_mode, 3) == 2
+            local screen_w = Screen.bb:getWidth()
+            local screen_h = Screen.bb:getHeight()
+            local is_landscape = screen_w > screen_h
 
-			-- Use fewer animation steps and shorter delay in landscape mode for better visual feel
-			local steps = is_landscape and 6 or 8
-			local delay_us = is_landscape and 9000 or 22000
+            -- Keep the existing animation profile for upright mode.
+            -- The portrait orientation opposite from the device's native startup
+            -- portrait uses a different generation strategy:
+            -- restore the previous page once, then only draw the newly revealed strip.
+            local steps = is_landscape and 6 or 8
+            local delay_us = is_landscape and 8000 or (is_opposite_portrait and 16000 or 22000)
+            local delay_setting_key = is_landscape and "swipe_animation_delay_ms_horizontal" or "swipe_animation_delay_ms_vertical"
+            local configured_delay_ms = tonumber(G_reader_settings:readSetting(delay_setting_key)) or 0
+            if configured_delay_ms <= 0 then
+                configured_delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms")) or 0
+            end
+            if configured_delay_ms > 0 then
+                delay_us = configured_delay_ms * 1000
+            end
 
-			local swipe_forward = Screen.swipe_forward
-			local prev_dx = 0
+            local swipe_forward = Screen.swipe_forward
+            local prev_dx = 0
 
-			-- Draw the previous page as the starting background
-			Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w, screen_h)
+            if is_landscape or is_opposite_portrait then
+                Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w, screen_h)
+            end
 
-			-- Animate page turn by progressively revealing vertical strips of the new page
-			for i = 1, steps do
-				local progress = i / steps
-				local dx = math.floor(screen_w * progress)
-				local strip_w = dx - prev_dx
+            for i = 1, steps do
+                local progress = i / steps
+                local dx = math.floor(screen_w * progress)
+                local strip_w = dx - prev_dx
 
-				if strip_w > 0 then
-					local strip_x
-					if swipe_forward then
-						-- Swipe forward (right to left): reveal from the right edge
-						strip_x = screen_w - dx
-					else
-						-- Swipe backward (left to right): reveal from the left edge
-						strip_x = prev_dx
-					end
+                if strip_w > 0 then
+                    if is_landscape or is_opposite_portrait then
+                        if swipe_forward then
+                            local strip_x = screen_w - dx
+                            Screen.bb:blitFrom(new_bb, strip_x, 0, strip_x, 0, strip_w, screen_h)
+                            Screen:refreshUI(strip_x, 0, strip_w, screen_h)
+                        else
+                            Screen.bb:blitFrom(new_bb, prev_dx, 0, prev_dx, 0, strip_w, screen_h)
+                            Screen:refreshUI(prev_dx, 0, strip_w, screen_h)
+                        end
+                    elseif swipe_forward then
+                        Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w - dx, screen_h)
+                        Screen.bb:blitFrom(new_bb, screen_w - dx, 0, screen_w - dx, 0, dx, screen_h)
+                        Screen:refreshUI(screen_w - dx, 0, strip_w, screen_h)
+                    else
+                        Screen.bb:blitFrom(new_bb, 0, 0, 0, 0, dx, screen_h)
+                        Screen.bb:blitFrom(saved_bb, dx, 0, dx, 0, screen_w - dx, screen_h)
+                        Screen:refreshUI(prev_dx, 0, strip_w, screen_h)
+                    end
+                end
 
-					-- Copy a vertical strip from the new page onto the current screen buffer
-					Screen.bb:blitFrom(new_bb, strip_x, 0, strip_x, 0, strip_w, screen_h)
-					Screen:refreshUI(strip_x, 0, strip_w, screen_h)
-				end
+                prev_dx = dx
 
-				prev_dx = dx
+                if ffi and ffi.C and ffi.C.usleep then
+                    ffi.C.usleep(delay_us)
+                end
+            end
 
-				-- Control animation speed with microsecond delay between strips
-				if ffi and ffi.C and ffi.C.usleep then
-					ffi.C.usleep(delay_us)
-				end
-			end
+            -- Skip the animation-specific full-refresh counter in night mode
+            -- to avoid an extra flash during dark reading.
+            if not G_reader_settings:isTrue("night_mode")
+                or G_reader_settings:isTrue("swipe_animation_night_full_refresh") then
+                if self.FULL_REFRESH_COUNT and self.FULL_REFRESH_COUNT > 0 then
+                    if not self._swipe_full_refresh_count then
+                        self._swipe_full_refresh_count = 0
+                    end
 
-			-- Independent full refresh counter
-			-- Periodically triggers a full screen refresh according to the user's
-			-- FULL_REFRESH_COUNT setting (from E-ink options) to reduce ghosting
-			if self.FULL_REFRESH_COUNT and self.FULL_REFRESH_COUNT > 0 then
-				if not self._swipe_full_refresh_count then
-					self._swipe_full_refresh_count = 0
-				end
-				self._swipe_full_refresh_count = self._swipe_full_refresh_count + 1
+                    self._swipe_full_refresh_count = self._swipe_full_refresh_count + 1
 
-				if self._swipe_full_refresh_count >= self.FULL_REFRESH_COUNT then
-					Screen:refreshFull(0, 0, screen_w, screen_h)
-					self._swipe_full_refresh_count = 0
-				end
-			end
+                    if self._swipe_full_refresh_count >= self.FULL_REFRESH_COUNT then
+                        Screen:refreshFull(0, 0, screen_w, screen_h)
+                        self._swipe_full_refresh_count = 0
+                    end
+                end
+            end
 
-			self._refresh_stack = {}
-			new_bb:free()
-			saved_bb:free()
-		end
-	end
-
+            self._refresh_stack = {}
+            new_bb:free()
+            saved_bb:free()
+        end
+    end
     -- execute refreshes:
     for _, refresh in ipairs(self._refresh_stack) do
         -- Honor dithering hints from *anywhere* in the dirty stack

--- a/patches/2-page-turn-animation-settings.lua
+++ b/patches/2-page-turn-animation-settings.lua
@@ -155,22 +155,6 @@ local ok, err = pcall(function()
     local function buildSwipeAnimationSubItems()
         return {
             {
-                text = "夜间模式下允许完全刷新",
-                enabled_func = function()
-                    return G_reader_settings:isTrue("swipe_animations")
-                end,
-                checked_func = function()
-                    return G_reader_settings:isTrue("swipe_animation_night_full_refresh")
-                end,
-                callback = function()
-                    G_reader_settings:flipNilOrFalse("swipe_animation_night_full_refresh")
-                end,
-                help_text = [[
-启用后，夜间模式下的翻页动画仍然可以按完全刷新频率执行全刷。
-
-禁用后，夜间模式下的翻页动画会跳过这类额外全刷，以减少闪屏。]],
-            },
-            {
                 text_func = function()
                     local configured = getConfiguredSwipeAnimationDelayMs()
                     local _, orientation_label = getSwipeAnimationDelaySettingKey()
@@ -191,22 +175,6 @@ local ok, err = pcall(function()
 
 直接输入毫秒数即可。竖屏和横屏会分别记住各自的数值。未自定义时，会显示当前方向使用的默认值。]],
             },
-            {
-                text = "夜间模式下禁用动画",
-                enabled_func = function()
-                    return G_reader_settings:isTrue("swipe_animations")
-                end,
-                checked_func = function()
-                    return G_reader_settings:isTrue("swipe_animation_disable_in_night_mode")
-                end,
-                callback = function()
-                    G_reader_settings:flipNilOrFalse("swipe_animation_disable_in_night_mode")
-                end,
-                help_text = [[
-启用后，只要夜间模式处于开启状态，就不执行翻页动画。
-
-禁用后，夜间模式下仍然可以使用翻页动画。]],
-            },
         }
     end
 
@@ -217,9 +185,7 @@ local ok, err = pcall(function()
                 return G_reader_settings:isTrue("swipe_animations")
             end,
             help_text = [[
-集中调整翻页动画相关选项。
-
-启用翻页动画后，可在这里调整夜间模式和速度相关设置。]],
+调整翻页动画的速度（帧延迟设置）。]],
             sub_item_table = buildSwipeAnimationSubItems(),
         }
     end

--- a/patches/2-page-turn-animation-settings.lua
+++ b/patches/2-page-turn-animation-settings.lua
@@ -45,7 +45,7 @@ local ok, err = pcall(function()
         local screen_h = Screen.bb:getHeight()
         local is_landscape = screen_w > screen_h
         if is_landscape then
-            return 8
+            return 10
         end
 
         local rotation_mode = Screen:getRotationMode()

--- a/patches/2-page-turn-animation-settings.lua
+++ b/patches/2-page-turn-animation-settings.lua
@@ -1,0 +1,253 @@
+local ok, err = pcall(function()
+    local Device = require("device")
+    if not Device:canDoSwipeAnimation() then
+        return
+    end
+
+    local ReaderMenu = require("apps/reader/modules/readermenu")
+    local reader_menu_order = require("ui/elements/reader_menu_order")
+    local Screen = Device.screen
+    local UIManager = require("ui/uimanager")
+    local T = require("ffi/util").template
+
+    local MENU_KEY = "page_turn_animation_settings"
+
+    if ReaderMenu._page_turn_animation_settings_patch_applied then
+        return
+    end
+    ReaderMenu._page_turn_animation_settings_patch_applied = true
+
+    local function ensureMenuKey(order_table)
+        if type(order_table) ~= "table" then
+            return
+        end
+
+        for i = #order_table, 1, -1 do
+            if order_table[i] == MENU_KEY then
+                table.remove(order_table, i)
+            end
+        end
+
+        for index, key in ipairs(order_table) do
+            if key == "page_turns" then
+                table.insert(order_table, index + 1, MENU_KEY)
+                return
+            end
+        end
+
+        table.insert(order_table, MENU_KEY)
+    end
+
+    ensureMenuKey(reader_menu_order.taps_and_gestures)
+
+    local function getAutomaticSwipeAnimationDelayMs()
+        local screen_w = Screen.bb:getWidth()
+        local screen_h = Screen.bb:getHeight()
+        local is_landscape = screen_w > screen_h
+        if is_landscape then
+            return 8
+        end
+
+        local rotation_mode = Screen:getRotationMode()
+        local native_rotation_mode = Screen.native_rotation_mode or Screen.DEVICE_ROTATED_UPRIGHT
+        local is_opposite_portrait = bit.band(rotation_mode - native_rotation_mode, 3) == 2
+        return is_opposite_portrait and 16 or 22
+    end
+
+    local function isLandscapeScreen()
+        return Screen.bb:getWidth() > Screen.bb:getHeight()
+    end
+
+    local function getSwipeAnimationDelaySettingKey()
+        if isLandscapeScreen() then
+            return "swipe_animation_delay_ms_horizontal", "横屏"
+        end
+        return "swipe_animation_delay_ms_vertical", "竖屏"
+    end
+
+    local function getConfiguredSwipeAnimationDelayMs()
+        local key = getSwipeAnimationDelaySettingKey()
+        local delay_ms = tonumber(G_reader_settings:readSetting(key)) or 0
+        if delay_ms <= 0 then
+            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms")) or 0
+        end
+        if delay_ms > 0 then
+            return delay_ms
+        end
+        return nil
+    end
+
+    local function saveConfiguredSwipeAnimationDelayMs(delay_ms)
+        local key = getSwipeAnimationDelaySettingKey()
+        local legacy_delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms")) or 0
+        if legacy_delay_ms > 0 then
+            if (tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_vertical")) or 0) <= 0 then
+                G_reader_settings:saveSetting("swipe_animation_delay_ms_vertical", legacy_delay_ms)
+            end
+            if (tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_horizontal")) or 0) <= 0 then
+                G_reader_settings:saveSetting("swipe_animation_delay_ms_horizontal", legacy_delay_ms)
+            end
+            G_reader_settings:delSetting("swipe_animation_delay_ms")
+        end
+        if delay_ms and delay_ms > 0 then
+            G_reader_settings:saveSetting(key, delay_ms)
+        else
+            G_reader_settings:delSetting(key)
+        end
+    end
+
+    local function showSwipeAnimationDelayInputDialog(touchmenu_instance)
+        local InputDialog = require("ui/widget/inputdialog")
+        local current_value = tostring(getConfiguredSwipeAnimationDelayMs() or getAutomaticSwipeAnimationDelayMs())
+        local default_delay_ms = getAutomaticSwipeAnimationDelayMs()
+        local _, orientation_label = getSwipeAnimationDelaySettingKey()
+        local input_dialog
+
+        input_dialog = InputDialog:new{
+            title = "动画帧延迟",
+            input = current_value,
+            input_type = "number",
+            description = T([[
+输入每一帧之间的延迟，单位为毫秒。
+
+数值越低，速度越快，但可能残影更明显。
+数值越高，速度越慢，但显示可能更干净。
+
+当前保存方向：%1
+当前默认值：%2 毫秒]], orientation_label, default_delay_ms),
+            buttons = {
+                {
+                    {
+                        text = "取消",
+                        callback = function()
+                            UIManager:close(input_dialog)
+                        end,
+                    },
+                    {
+                        text = "恢复默认",
+                        callback = function()
+                            saveConfiguredSwipeAnimationDelayMs(nil)
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                            UIManager:close(input_dialog)
+                        end,
+                    },
+                    {
+                        text = "保存",
+                        is_enter_default = true,
+                        callback = function()
+                            local value = input_dialog:getInputValue()
+                            if not value or value < 1 then
+                                saveConfiguredSwipeAnimationDelayMs(nil)
+                            else
+                                saveConfiguredSwipeAnimationDelayMs(value)
+                            end
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                            UIManager:close(input_dialog)
+                        end,
+                    },
+                },
+            },
+        }
+        UIManager:show(input_dialog)
+        input_dialog:onShowKeyboard()
+    end
+
+    local function buildSwipeAnimationSubItems()
+        return {
+            {
+                text = "夜间模式下允许完全刷新",
+                enabled_func = function()
+                    return G_reader_settings:isTrue("swipe_animations")
+                end,
+                checked_func = function()
+                    return G_reader_settings:isTrue("swipe_animation_night_full_refresh")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("swipe_animation_night_full_refresh")
+                end,
+                help_text = [[
+启用后，夜间模式下的翻页动画仍然可以按完全刷新频率执行全刷。
+
+禁用后，夜间模式下的翻页动画会跳过这类额外全刷，以减少闪屏。]],
+            },
+            {
+                text_func = function()
+                    local configured = getConfiguredSwipeAnimationDelayMs()
+                    local _, orientation_label = getSwipeAnimationDelaySettingKey()
+                    if configured then
+                        return T("%1动画帧延迟：%2 毫秒", orientation_label, configured)
+                    end
+                    return T("%1动画帧延迟：默认 %2 毫秒", orientation_label, getAutomaticSwipeAnimationDelayMs())
+                end,
+                enabled_func = function()
+                    return G_reader_settings:isTrue("swipe_animations")
+                end,
+                keep_menu_open = true,
+                callback = function(touchmenu_instance)
+                    showSwipeAnimationDelayInputDialog(touchmenu_instance)
+                end,
+                help_text = [[
+调整翻页动画每一帧之间的停顿时间。
+
+直接输入毫秒数即可。竖屏和横屏会分别记住各自的数值。未自定义时，会显示当前方向使用的默认值。]],
+            },
+            {
+                text = "夜间模式下禁用动画",
+                enabled_func = function()
+                    return G_reader_settings:isTrue("swipe_animations")
+                end,
+                checked_func = function()
+                    return G_reader_settings:isTrue("swipe_animation_disable_in_night_mode")
+                end,
+                callback = function()
+                    G_reader_settings:flipNilOrFalse("swipe_animation_disable_in_night_mode")
+                end,
+                help_text = [[
+启用后，只要夜间模式处于开启状态，就不执行翻页动画。
+
+禁用后，夜间模式下仍然可以使用翻页动画。]],
+            },
+        }
+    end
+
+    local function buildSettingsMenu()
+        return {
+            text = "翻页动画设置",
+            enabled_func = function()
+                return G_reader_settings:isTrue("swipe_animations")
+            end,
+            help_text = [[
+集中调整翻页动画相关选项。
+
+启用翻页动画后，可在这里调整夜间模式和速度相关设置。]],
+            sub_item_table = buildSwipeAnimationSubItems(),
+        }
+    end
+
+    local function injectSettingsMenu(menu_items)
+        if type(menu_items) ~= "table" then
+            return false
+        end
+
+        local existing = menu_items[MENU_KEY]
+        if type(existing) == "table" and existing._page_turn_animation_settings_patch_item then
+            existing.sub_item_table = buildSwipeAnimationSubItems()
+            return true
+        end
+
+        local item = buildSettingsMenu()
+        item._page_turn_animation_settings_patch_item = true
+        menu_items[MENU_KEY] = item
+        return true
+    end
+
+    local orig_setUpdateItemTable = ReaderMenu.setUpdateItemTable
+    ReaderMenu.setUpdateItemTable = function(self, ...)
+        injectSettingsMenu(self.menu_items)
+        return orig_setUpdateItemTable(self, ...)
+    end
+end)
+
+if not ok then
+    require("logger").warn("[PageTurnAnimationSettingsPatch] failed:", err)
+end


### PR DESCRIPTION
## Summary
- tune the non-MTK software swipe animation path for opposite portrait rotation and landscape
- support separate horizontal/vertical animation delay settings in 
- skip the animation-specific full-refresh counter in night mode unless explicitly enabled
- add an optional user patch at  that exposes animation settings as a sibling menu item below 页面翻页/Page turns

## Notes
- the new settings UI lives in a standalone patch file so  does not need to be modified
- the patch injects a sibling menu entry instead of editing the built-in Page turns submenu directly to keep the hook simpler and more stable
