### PR TITLE
feat: skip animation on clearing pages + mild global refresh option

### DIFF
--- a/frontend/ui/uimanager.lua
+++ b/frontend/ui/uimanager.lua
@@ -1294,7 +1294,7 @@ function UIManager:_repaint()
         self:_refresh("partial")
     end
 
--- Execute a software swipe animation when requested on non-MTK devices.
+    -- Execute a software swipe animation when requested on non-MTK devices.
     local software_animate = false
     if Screen.swipe_animations then
         software_animate = true
@@ -1305,48 +1305,67 @@ function UIManager:_repaint()
         Screen.swipe_animations = false
         self.refresh_counted = true
 
-        -- ==================== Integration with swipe-animation-settings plugin ====================
-        -- Support custom per-orientation animation frame delay set by the external plugin
-
-        -- Default animation frame delays (used when no custom value is set by user):
-        --   Landscape: 10ms
-        --   Portrait:  20ms
         local screen_w = Screen.bb:getWidth()
         local screen_h = Screen.bb:getHeight()
-        local is_landscape = screen_w > screen_h
 
-        local delay_ms = 0
-        if is_landscape then
-            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_horizontal")) or 0
-        else
-            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_vertical")) or 0
+        -- Independent full refresh counter (moved up so we can skip the animation
+        -- entirely when a clearing refresh is due). Required because we bypassed
+        -- the normal partial→full promotion counting in this software animation path.
+        -- Periodically triggers a full/partial screen refresh according to the user's
+        -- FULL_REFRESH_COUNT setting (from E-ink options) to reduce ghosting.
+        local do_clearing = false
+        if self.FULL_REFRESH_COUNT and self.FULL_REFRESH_COUNT > 0 then
+            self._swipe_full_refresh_count = (self._swipe_full_refresh_count or 0) + 1
+            if self._swipe_full_refresh_count >= self.FULL_REFRESH_COUNT then
+                do_clearing = true
+                self._swipe_full_refresh_count = 0
+            end
         end
-        if delay_ms <= 0 then
-            delay_ms = is_landscape and 10 or 20
-        end
-        local delay_us = delay_ms * 1000
-
-        -- ==================== Refresh mode selection (from swipe-animation-settings plugin) ====================
-        -- Allow user to choose "ui", "partial" or "fast" for the per-strip refreshes.
-        -- This trades off between visual quality / ghosting and animation fluidity.
-        local anim_refresh_mode = G_reader_settings:readSetting("swipe_animation_refresh_mode") or "ui"
-        local refresh_fn = refresh_methods[anim_refresh_mode] or refresh_methods["ui"]
-        if not refresh_fn then
-            refresh_fn = Screen.refreshUI
-        end
-
-        -- Hoisted for slight efficiency in the animation loop
-        local usleep = ffi and ffi.C and ffi.C.usleep
 
         local saved_bb = Screen.saved_bb
         Screen.saved_bb = nil
 
-        if saved_bb then
+        if do_clearing then
+            -- Clearing page: skip the wipe animation and just issue the selected
+            -- refresh mode. When "mild global refresh" is enabled we use partial,
+            -- otherwise a true full refresh.
+            if G_reader_settings:isTrue("swipe_animation_mild_global_refresh") then
+                Screen:refreshPartial(0, 0, screen_w, screen_h)
+            else
+                Screen:refreshFull(0, 0, screen_w, screen_h)
+            end
+            if saved_bb then
+                saved_bb:free()
+            end
+            self._refresh_stack = {}
+            self.refresh_count = 0
+        elseif saved_bb then
+            -- ==================== Normal software swipe animation path ====================
             local new_bb = Screen.bb:copy()
+
+            -- Support custom per-orientation animation frame delay set by the external plugin.
+            -- Default animation frame delays (used when no custom value is set by user):
+            --   Landscape: 10ms
+            --   Portrait:  20ms
+            local is_landscape = screen_w > screen_h
+            local delay_ms = is_landscape
+                and (tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_horizontal")) or 0)
+                or  (tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_vertical")) or 0)
+            if delay_ms <= 0 then
+                delay_ms = is_landscape and 10 or 20
+            end
+            local delay_us = delay_ms * 1000
+
+            -- Allow user to choose "ui" or "fast" for the per-strip refreshes.
+            -- This trades off between visual quality / ghosting and animation fluidity.
+            local anim_refresh_mode = G_reader_settings:readSetting("swipe_animation_refresh_mode") or "ui"
+            local refresh_fn = refresh_methods[anim_refresh_mode] or refresh_methods.ui or Screen.refreshUI
+
+            -- Hoisted for slight efficiency in the animation loop
+            local usleep = ffi and ffi.C and ffi.C.usleep
 
             -- Use fewer animation steps in landscape mode for better visual feel
             local steps = is_landscape and 6 or 8
-
             local swipe_forward = Screen.swipe_forward
             local prev_dx = 0
 
@@ -1360,94 +1379,69 @@ function UIManager:_repaint()
                 local progress = i / steps
                 local dx = math.floor(screen_w * progress)
                 local strip_w = dx - prev_dx
-
                 if strip_w > 0 then
-                    local strip_x
-                    if swipe_forward then
-                        -- Swipe forward (right to left): reveal from the right edge
-                        strip_x = screen_w - dx
-                    else
-                        -- Swipe backward (left to right): reveal from the left edge
-                        strip_x = prev_dx
-                    end
-
+                    local strip_x = swipe_forward and (screen_w - dx) or prev_dx
                     -- Copy a vertical strip from the new page onto the current screen buffer
                     Screen.bb:blitFrom(new_bb, strip_x, 0, strip_x, 0, strip_w, screen_h)
                     refresh_fn(Screen, strip_x, 0, strip_w, screen_h)
                 end
-
                 prev_dx = dx
-
                 -- Control animation speed with microsecond delay between strips
                 if usleep then
                     usleep(delay_us)
                 end
             end
-
-            -- Independent full refresh counter (required here because we bypassed
-            -- the normal partial->full promotion counting in this software animation path).
-            -- Periodically triggers a full screen refresh according to the user's
-            -- FULL_REFRESH_COUNT setting (from E-ink options) to reduce ghosting.
-            if self.FULL_REFRESH_COUNT and self.FULL_REFRESH_COUNT > 0 then
-                if not self._swipe_full_refresh_count then
-                    self._swipe_full_refresh_count = 0
-                end
-                self._swipe_full_refresh_count = self._swipe_full_refresh_count + 1
-
-                if self._swipe_full_refresh_count >= self.FULL_REFRESH_COUNT then
-                    Screen:refreshFull(0, 0, screen_w, screen_h)
-                    self._swipe_full_refresh_count = 0
-                end
-            end
+            -- Final full-screen refresh using the same mode as the animation strips
+            refresh_fn(Screen, 0, 0, screen_w, screen_h)
 			
-		-- ==================== Restore original KOReader full-refresh behavior ====================
-        -- The software animation path bypasses the normal partial→full promotion logic.
-        -- Re-apply the original conditions that force a full refresh on:
-        --   1. pages with significant image coverage (refresh_on_pages_with_images)
-        --   2. chapter boundaries (refresh_on_chapter_boundaries / FULL_REFRESH_COUNT == -1)
-        local need_full = false
-        local readerui = require("apps/reader/readerui")
-        local instance = readerui and readerui.instance
+            -- ==================== Restore original KOReader full-refresh behavior ====================
+            -- The software animation path bypasses the normal partial→full promotion logic.
+            -- Re-apply the original conditions that force a full refresh on:
+            --   1. pages with significant image coverage (refresh_on_pages_with_images)
+            --   2. chapter boundaries (refresh_on_chapter_boundaries / FULL_REFRESH_COUNT == -1)
+            local need_full = false
+            local readerui = require("apps/reader/readerui")
+            local instance = readerui and readerui.instance
 
-        if instance then
-            -- Image pages: mirror the exact check performed in ReaderView:paintTo
-            local view = instance.view
-            if view and view.img_coverage and view.img_coverage >= 0.075 then
-                if G_reader_settings:nilOrTrue("refresh_on_pages_with_images") then
-                    need_full = true
-                end
-            end
-
-            -- Chapter boundaries
-            if not need_full then
-                local flash_on_chapter = G_reader_settings:isTrue("refresh_on_chapter_boundaries")
-                -- Also honor the "Every chapter" setting (FULL_REFRESH_COUNT == -1)
-                if not flash_on_chapter and self.FULL_REFRESH_COUNT == -1 then
-                    flash_on_chapter = true
+            if instance then
+                -- Image pages: mirror the exact check performed in ReaderView:paintTo
+                local view = instance.view
+                if view and view.img_coverage and view.img_coverage >= 0.075 then
+                    if G_reader_settings:nilOrTrue("refresh_on_pages_with_images") then
+                        need_full = true
+                    end
                 end
 
-                if flash_on_chapter then
-                    local toc = instance.toc
-                    local paging = instance.paging
-                    local current_page = paging and paging.current_page
+                -- Chapter boundaries
+                if not need_full then
+                    local flash_on_chapter = G_reader_settings:isTrue("refresh_on_chapter_boundaries")
+                    -- Also honor the "Every chapter" setting (FULL_REFRESH_COUNT == -1)
+                    if not flash_on_chapter and self.FULL_REFRESH_COUNT == -1 then
+                        flash_on_chapter = true
+                    end
 
-                    if toc and current_page and toc:isChapterStart(current_page) then
-                        -- Honor the original "except on the second page of a new chapter" option
-                        local no_second = G_reader_settings:isTrue("no_refresh_on_second_chapter_page")
-                        if not (no_second and current_page > 1 and toc:isChapterStart(current_page - 1)) then
-                            need_full = true
+                    if flash_on_chapter then
+                        local toc = instance.toc
+                        local paging = instance.paging
+                        local current_page = paging and paging.current_page
+
+                        if toc and current_page and toc:isChapterStart(current_page) then
+                            -- Honor the original "except on the second page of a new chapter" option
+                            local no_second = G_reader_settings:isTrue("no_refresh_on_second_chapter_page")
+                            if not (no_second and current_page > 1 and toc:isChapterStart(current_page - 1)) then
+                                need_full = true
+                            end
                         end
                     end
                 end
             end
-        end
 
-        if need_full then
-            Screen:refreshFull(0, 0, screen_w, screen_h)
-            -- Reset counters to stay consistent with normal full-refresh behavior
-            self._swipe_full_refresh_count = 0
-            self.refresh_count = 0
-        end
+            if need_full then
+                Screen:refreshFull(0, 0, screen_w, screen_h)
+                -- Reset counters to stay consistent with normal full-refresh behavior
+                self._swipe_full_refresh_count = 0
+                self.refresh_count = 0
+            end
 
             self._refresh_stack = {}
             new_bb:free()

--- a/patches/2-swipe-animation-settings.lua
+++ b/patches/2-swipe-animation-settings.lua
@@ -106,22 +106,37 @@ local ok, err = pcall(function()
             G_reader_settings:delSetting(key)
         end
     end
+    -- ==================== Mild global refresh for the independent counter ====================
+    -- When enabled, the periodic clearing refresh (triggered by the independent
+    -- counter) uses a partial refresh instead of a true full refresh.
+    -- The page-turn animation is always skipped on the clearing page.
+    local function isMildGlobalRefreshEnabled()
+        return G_reader_settings:isTrue("swipe_animation_mild_global_refresh")
+    end
 
+    local function toggleMildGlobalRefresh()
+        local enabled = not isMildGlobalRefreshEnabled()
+        if enabled then
+            G_reader_settings:saveSetting("swipe_animation_mild_global_refresh", true)
+        else
+            G_reader_settings:delSetting("swipe_animation_mild_global_refresh")
+        end
+    end
     -- ==================== Refresh mode for software swipe animation ====================
-    -- Allows user to choose between "ui", "partial", "fast" for the strip refreshes
+    -- Allows user to choose between "ui", "fast" for the strip refreshes
     -- in the software page-turn animation (implemented in UIManager:_repaint).
     local function getSwipeAnimationRefreshMode()
         local mode = G_reader_settings:readSetting("swipe_animation_refresh_mode")
-        if mode == "partial" or mode == "fast" then
+        if mode == "fast" then
             return mode
         end
         return "ui"
     end
-
+    
     local function saveSwipeAnimationRefreshMode(mode)
         if mode == "ui" then
             G_reader_settings:delSetting("swipe_animation_refresh_mode")
-        elseif mode == "partial" or mode == "fast" then
+        elseif mode == "fast" then
             G_reader_settings:saveSetting("swipe_animation_refresh_mode", mode)
         end
     end
@@ -184,7 +199,7 @@ local ok, err = pcall(function()
 
     local function buildSwipeAnimationSubItems()
         return {
-            -- NEW: Refresh mode chooser for the animation strips (put above delay as requested)
+            -- Refresh mode chooser
             {
                 text = "翻页动画刷新模式",
                 enabled_func = function()
@@ -194,7 +209,6 @@ local ok, err = pcall(function()
 选择软件翻页动画中，每一小条画面更新时使用的刷新类型。
 
 • UI刷新（默认）：平衡画质与速度，适合大多数情况。
-• Partial刷新：对纯文字/白底内容优化，残影控制较好。
 • Fast刷新：速度最快，适合追求流畅度但可接受较多残影的场景。
 
 更改后立即生效。]],
@@ -206,18 +220,6 @@ local ok, err = pcall(function()
                         end,
                         callback = function(touchmenu_instance)
                             saveSwipeAnimationRefreshMode("ui")
-                            if touchmenu_instance then
-                                touchmenu_instance:updateItems()
-                            end
-                        end,
-                    },
-                    {
-                        text = "Partial刷新（文字优化）",
-                        checked_func = function()
-                            return getSwipeAnimationRefreshMode() == "partial"
-                        end,
-                        callback = function(touchmenu_instance)
-                            saveSwipeAnimationRefreshMode("partial")
                             if touchmenu_instance then
                                 touchmenu_instance:updateItems()
                             end
@@ -237,7 +239,7 @@ local ok, err = pcall(function()
                     },
                 },
             },
-            -- Delay setting (existing, now below refresh mode)
+            -- Delay setting 
             {
                 text_func = function()
                     local configured = getConfiguredSwipeAnimationDelayMs()
@@ -259,6 +261,26 @@ local ok, err = pcall(function()
 
 直接输入毫秒数即可。竖屏和横屏会分别记住各自的数值。未自定义时，会显示当前方向使用的默认值。]],
             },
+            -- Clearing page mode chooser 
+            {
+                text = "轻度全局刷新",
+                enabled_func = function()
+                    return G_reader_settings:isTrue("swipe_animations")
+                end,
+                checked_func = function()
+                    return isMildGlobalRefreshEnabled()
+                end,
+                callback = function(touchmenu_instance)
+                    toggleMildGlobalRefresh()
+                    if touchmenu_instance then
+                        touchmenu_instance:updateItems()
+                    end
+                end,
+                help_text = [[
+• 勾选：使用 Partial 刷新（适用于纯文字内容）
+
+• 未勾选：使用 Full 刷新（适用于图文内容）]],
+            },
         }
     end
 
@@ -269,7 +291,7 @@ local ok, err = pcall(function()
                 return G_reader_settings:isTrue("swipe_animations")
             end,
             help_text = [[
-调整软件翻页动画的速度（帧延迟）和画面更新刷新模式（UI / Partial / Fast）。
+调整软件翻页动画的速度（帧延迟）和画面更新刷新模式（UI / Fast）。
 
 刷新模式直接影响动画期间每条画面的更新质量与残影表现。]],
             sub_item_table = buildSwipeAnimationSubItems(),


### PR DESCRIPTION
- When _swipe_full_refresh_count triggers, skip the wipe animation and do a clean full/partial refresh instead
- Add '轻度全局刷新' toggle (partial vs full for clearing pages)
- Force canDoSwipeAnimation + simplify strip refresh modes to UI/Fast