### PR TITLE
feat: delay 0 skips usleep; Kobo MTK wipe fence

### DIFF
--- a/patches/2-swipe-animation-core.lua
+++ b/patches/2-swipe-animation-core.lua
@@ -347,18 +347,27 @@ local ok, err = pcall(function()
         -- Defaults come from UIManager.swipe_animation_defaults (single source of truth).
         local is_landscape = screen_w > screen_h
         local delay_defaults = (UIManager.swipe_animation_defaults or {}).delay_ms or {}
-        local delay_ms = is_landscape
-            and (tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_horizontal")) or 0)
-            or  (tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_vertical")) or 0)
-        if delay_ms <= 0 then
-            delay_ms = is_landscape
-                and (delay_defaults.landscape or 10)
-                or  (delay_defaults.portrait or 20)
-        end
-        local delay_us = delay_ms * 1000
-
-        -- Allow user to choose "ui" or "fast" for the per-strip refreshes.
         local anim_refresh_mode = G_reader_settings:readSetting("swipe_animation_refresh_mode") or "ui"
+        local delay_ms
+        if is_landscape then
+            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_horizontal"))
+        else
+            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms_vertical"))
+        end
+        if delay_ms == nil then
+            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms"))
+        end
+        -- Unset: UI defaults to 0 (ioctl-paced). Fast keeps 10/20ms.
+        -- Explicit 0 also means no usleep.
+        if delay_ms == nil or delay_ms < 0 then
+            if anim_refresh_mode == "fast" then
+                delay_ms = is_landscape
+                    and (delay_defaults.landscape or 10)
+                    or  (delay_defaults.portrait or 20)
+            else
+                delay_ms = 0
+            end
+        end
 
         -- Hoisted for slight efficiency in the animation loop
         local usleep = ffi and ffi.C and ffi.C.usleep
@@ -400,8 +409,8 @@ local ok, err = pcall(function()
                 local refresh_fn = use_fast and Screen.refreshFast or Screen.refreshUI
                 refresh_fn(Screen, left, 0, strip_w, screen_h)
             end
-            if i < nslots and usleep and use_fast then
-                usleep(delay_us)
+            if i < nslots and usleep and delay_ms > 0 then
+                usleep(delay_ms * 1000)
             end
         end
 

--- a/patches/2-swipe-animation-core.lua
+++ b/patches/2-swipe-animation-core.lua
@@ -317,16 +317,11 @@ local ok, err = pcall(function()
         if delay_ms == nil then
             delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms"))
         end
-        -- Unset: UI defaults to 0 (ioctl-paced). Fast keeps 10/20ms.
-        -- Explicit 0 also means no usleep.
+        -- Unset: 10/20ms for both UI and Fast. Explicit 0 means no usleep.
         if delay_ms == nil or delay_ms < 0 then
-            if anim_refresh_mode == "fast" then
-                delay_ms = is_landscape
-                    and (delay_defaults.landscape or 10)
-                    or  (delay_defaults.portrait or 20)
-            else
-                delay_ms = 0
-            end
+            delay_ms = is_landscape
+                and (delay_defaults.landscape or 10)
+                or  (delay_defaults.portrait or 20)
         end
 
         -- Hoisted for slight efficiency in the animation loop

--- a/patches/2-swipe-animation-core.lua
+++ b/patches/2-swipe-animation-core.lua
@@ -14,12 +14,9 @@
     2. the SwipeAnimation module: full-refresh / clearing decisions and the
        wipe animation itself (runSwipeAnimation), called from
        UIManager:_repaint after the new page is painted.
-    3. post-resume display warm-up on MTK Kobos: the display controller is
-       still cold after wake-up, so the first software wipe animation would
-       run in slow motion because every UI-waveform strip refresh blocks on
-       the still-cold controller. Right after resume we issue a few invisible
-       full-screen UI refreshes to warm the controller up, so the first page
-       turn animates normally at full speed.
+    3. Kobo MTK fence immediately before the wipe loop: drain a leftover
+       PARTIAL, or pay one AUTO+wait after a FULL, so the first strips are
+       not blocked by HWTCON serialization.
 
     Prefer original data sources, but trigger Screen:refreshFull / refreshPartial
     directly (because we are inside _repaint, where setDirty would be deferred
@@ -97,43 +94,6 @@ local ok, err = pcall(function()
     local ffi = require("ffi")
 
     local SwipeAnimation = {}
-
-    ---------------------------------------------------------------
-    --     Post-resume display warm-up on MTK Kobo
-    ---------------------------------------------------------------
-    if not UIManager._swipe_animation_resume_warmup_patched then
-        UIManager._swipe_animation_resume_warmup_patched = true
-
-        local orig_broadcastEvent = UIManager.broadcastEvent
-        function UIManager:broadcastEvent(ev)
-            local ret = orig_broadcastEvent(self, ev)
-            if ev and ev.handler == "onResume"
-                    and Device:isKobo() and Device:isMTK()
-                    and G_reader_settings:isTrue("swipe_animations") then
-                UIManager:scheduleIn(0.3, function()
-                    if Device.screen_saver_mode then
-                        return -- device went back to sleep meanwhile
-                    end
-                    local bb = Screen.bb
-                    if not bb then
-                        return
-                    end
-                    local warmup_w = bb:getWidth()
-                    local warmup_h = bb:getHeight()
-                    if warmup_w <= 0 or warmup_h <= 0 then
-                        return
-                    end
-                    -- Same refresh count as a portrait wipe animation, so the
-                    -- controller is exercised just as much as it was during
-                    -- the previously slow first turn.
-                    for _ = 1, 8 do
-                        Screen:refreshUI(0, 0, warmup_w, warmup_h)
-                    end
-                end)
-            end
-            return ret
-        end
-    end
 
     ---------------------------------------------------------------
     -- 2.1 Whether to skip the animation and perform a clearing refresh
@@ -389,6 +349,21 @@ local ok, err = pcall(function()
         -- Draw the previous page as the starting background
         Screen.bb:blitFrom(saved_bb, 0, 0, 0, 0, screen_w, screen_h)
 
+        -- Kobo MTK: leftover PARTIAL AUTO still serializes the first strip;
+        -- after a FULL, waitForLast is a no-op (dont_wait_for_marker == marker)
+        -- so pay one AUTO+wait here. Consecutive turns skip the extra refresh.
+        if Device:isKobo() and Device:isMTK() then
+            if Screen.refreshWaitForLast then
+                Screen:refreshWaitForLast()
+            end
+            if Screen.dont_wait_for_marker == Screen.marker then
+                Screen:refreshUI(0, 0, screen_w, screen_h)
+                if Screen.refreshWaitForLast then
+                    Screen:refreshWaitForLast()
+                end
+            end
+        end
+
         -- Animate page turn by progressively revealing vertical strips of the new page.
         for i = 1, nslots do
             local left, right
@@ -401,8 +376,6 @@ local ok, err = pcall(function()
                 right = edges[i + 1]
             end
             local strip_w = right - left
-            -- Sleep only after DU. UI already blocked on submission (MTK)
-            -- or is a slower waveform; extra usleep just makes it feel late.
             local use_fast = anim_refresh_mode == "fast"
             if strip_w > 0 then
                 Screen.bb:blitFrom(new_bb, left, 0, left, 0, strip_w, screen_h)

--- a/patches/2-swipe-animation-settings.lua
+++ b/patches/2-swipe-animation-settings.lua
@@ -236,10 +236,6 @@ O modo de atualização impacta diretamente na qualidade e no ghosting de cada f
     -- Simplified defaults come from UIManager.swipe_animation_defaults
     -- (the single source of truth for the animation tuning).
     local function getAutomaticSwipeAnimationDelayMs()
-        -- UI: 0 (pace with refresh ioctl only). Fast: 10/20ms.
-        if G_reader_settings:readSetting("swipe_animation_refresh_mode") ~= "fast" then
-            return 0
-        end
         local delay_defaults = (UIManager.swipe_animation_defaults or {}).delay_ms or {}
         if isLandscapeScreen() then
             return delay_defaults.landscape or 10

--- a/patches/2-swipe-animation-settings.lua
+++ b/patches/2-swipe-animation-settings.lua
@@ -42,18 +42,14 @@ local ok, err = pcall(function()
         ["Portrait"] = "竖屏",
         [ [[
 Enter the delay between animation frames, in milliseconds.
-
-0 = no extra pause (pace with each strip refresh).
-Lower values are faster but may cause more ghosting.
-Higher values are slower but usually look cleaner.
+0 = no extra pause (pace with strip refresh).
+Lower is faster, higher is slower.
 
 Current orientation: %1
 Current default: %2 ms]] ] = [[
 输入每一帧之间的延迟，单位为毫秒。
-
-0 = 不再额外停顿（节奏交给每次条带刷新）。
-数值越低，速度越快，但可能残影更明显。
-数值越高，速度越慢，但显示可能更干净。
+0 = 不再额外停顿（节奏交给条带刷新）。
+数值越低，速度越快，数值越高，速度越慢。
 
 当前保存方向：%1
 当前默认值：%2 毫秒]],
@@ -109,21 +105,17 @@ The refresh mode directly affects the quality and ghosting of each strip update 
         ["Portrait"] = "Modo retrato",
         [ [[
 Enter the delay between animation frames, in milliseconds.
-
-0 = no extra pause (pace with each strip refresh).
-Lower values are faster but may cause more ghosting.
-Higher values are slower but usually look cleaner.
+0 = no extra pause (pace with strip refresh).
+Lower is faster, higher is slower.
 
 Current orientation: %1
 Current default: %2 ms]] ] = [[
 Insira o intervalo entre quadros da animação, em milissegundos.
-
-0 = sem pausa extra (o ritmo fica a cargo de cada atualização).
-Valores menores são mais rápidos, mas podem gerar mais ghosting.
-Valores maiores são mais lentos, mas geralmente resultam em imagens mais limpas.
+0 = sem pausa extra (ritmo pela atualização das faixas).
+Menor é mais rápido, maior é mais lento.
 
 Orientação atual: %1
-Padrão da orientação atual: %2 ms]],
+Padrão atual: %2 ms]],
         [ [[
 Choose the refresh type used for each strip of the software swipe animation.
 
@@ -319,10 +311,8 @@ O modo de atualização impacta diretamente na qualidade e no ghosting de cada f
             input_type = "number",
             description = T(_([[
 Enter the delay between animation frames, in milliseconds.
-
-0 = no extra pause (pace with each strip refresh).
-Lower values are faster but may cause more ghosting.
-Higher values are slower but usually look cleaner.
+0 = no extra pause (pace with strip refresh).
+Lower is faster, higher is slower.
 
 Current orientation: %1
 Current default: %2 ms]]), orientation_label, default_delay_ms),

--- a/patches/2-swipe-animation-settings.lua
+++ b/patches/2-swipe-animation-settings.lua
@@ -43,6 +43,7 @@ local ok, err = pcall(function()
         [ [[
 Enter the delay between animation frames, in milliseconds.
 
+0 = no extra pause (pace with each strip refresh).
 Lower values are faster but may cause more ghosting.
 Higher values are slower but usually look cleaner.
 
@@ -50,6 +51,7 @@ Current orientation: %1
 Current default: %2 ms]] ] = [[
 输入每一帧之间的延迟，单位为毫秒。
 
+0 = 不再额外停顿（节奏交给每次条带刷新）。
 数值越低，速度越快，但可能残影更明显。
 数值越高，速度越慢，但显示可能更干净。
 
@@ -108,6 +110,7 @@ The refresh mode directly affects the quality and ghosting of each strip update 
         [ [[
 Enter the delay between animation frames, in milliseconds.
 
+0 = no extra pause (pace with each strip refresh).
 Lower values are faster but may cause more ghosting.
 Higher values are slower but usually look cleaner.
 
@@ -115,6 +118,7 @@ Current orientation: %1
 Current default: %2 ms]] ] = [[
 Insira o intervalo entre quadros da animação, em milissegundos.
 
+0 = sem pausa extra (o ritmo fica a cargo de cada atualização).
 Valores menores são mais rápidos, mas podem gerar mais ghosting.
 Valores maiores são mais lentos, mas geralmente resultam em imagens mais limpas.
 
@@ -232,6 +236,10 @@ O modo de atualização impacta diretamente na qualidade e no ghosting de cada f
     -- Simplified defaults come from UIManager.swipe_animation_defaults
     -- (the single source of truth for the animation tuning).
     local function getAutomaticSwipeAnimationDelayMs()
+        -- UI: 0 (pace with refresh ioctl only). Fast: 10/20ms.
+        if G_reader_settings:readSetting("swipe_animation_refresh_mode") ~= "fast" then
+            return 0
+        end
         local delay_defaults = (UIManager.swipe_animation_defaults or {}).delay_ms or {}
         if isLandscapeScreen() then
             return delay_defaults.landscape or 10
@@ -249,22 +257,22 @@ O modo de atualização impacta diretamente na qualidade e no ghosting de cada f
 
     local function getConfiguredSwipeAnimationDelayMs()
         local key = getSwipeAnimationDelaySettingKey()
-        local delay_ms = tonumber(G_reader_settings:readSetting(key)) or 0
-        if delay_ms <= 0 then
-            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms")) or 0
+        local delay_ms = tonumber(G_reader_settings:readSetting(key))
+        if delay_ms == nil then
+            delay_ms = tonumber(G_reader_settings:readSetting("swipe_animation_delay_ms"))
         end
-        if delay_ms > 0 then
-            return delay_ms
+        if delay_ms == nil or delay_ms < 0 then
+            return nil
         end
-        return nil
+        return delay_ms
     end
 
     local function saveConfiguredSwipeAnimationDelayMs(delay_ms)
         local key = getSwipeAnimationDelaySettingKey()
-        if delay_ms and delay_ms > 0 then
-            G_reader_settings:saveSetting(key, delay_ms)
-        else
+        if delay_ms == nil or delay_ms < 0 then
             G_reader_settings:delSetting(key)
+        else
+            G_reader_settings:saveSetting(key, delay_ms)
         end
     end
     -- ==================== Mild global refresh for the independent counter ====================
@@ -316,6 +324,7 @@ O modo de atualização impacta diretamente na qualidade e no ghosting de cada f
             description = T(_([[
 Enter the delay between animation frames, in milliseconds.
 
+0 = no extra pause (pace with each strip refresh).
 Lower values are faster but may cause more ghosting.
 Higher values are slower but usually look cleaner.
 
@@ -342,7 +351,7 @@ Current default: %2 ms]]), orientation_label, default_delay_ms),
                         is_enter_default = true,
                         callback = function()
                             local value = input_dialog:getInputValue()
-                            if not value or value < 1 then
+                            if value == nil or value < 0 then
                                 saveConfiguredSwipeAnimationDelayMs(nil)
                             else
                                 saveConfiguredSwipeAnimationDelayMs(value)


### PR DESCRIPTION
相对 #20 的后续改动。

## 帧延迟

- 未设置时，UI 和 Fast 都是竖屏 20ms / 横屏 10ms。
- 填 **0** 会存成 0，条带之间不 `usleep`，节奏交给 `refreshUI` / `refreshFast`（Kobo MTK 上即 `WAIT_FOR_UPDATE_SUBMISSION`）。
- 大于 0 才按设定毫秒数 `usleep`。「恢复默认」仍是清掉自定义值。
- 输入框说明改为更短的三行 + 当前方向 / 默认值，减轻横屏挡住输入框。

## Kobo MTK

- 擦除循环前 `refreshWaitForLast`。若上一枪已是 FULL，再补一次 `refreshUI` 并等完，避免第一、二条被 HWTCON 串行堵住。
- 去掉 resume 后 8 次全屏 `refreshUI` 预热（会和第一翻抢跑，并留下 in-flight AUTO）。

## 不在本次范围

- Fast 最后一条改 AUTO